### PR TITLE
Fix account selection on family/team plans

### DIFF
--- a/internal/jmap/client.go
+++ b/internal/jmap/client.go
@@ -24,11 +24,12 @@ type Client struct {
 
 // Session contains JMAP session information.
 type Session struct {
-	APIURL      string                 `json:"apiUrl"`
-	DownloadURL string                 `json:"downloadUrl"`
-	UploadURL   string                 `json:"uploadUrl"`
-	AccountID   string                 // First account ID
-	Accounts    map[string]interface{} `json:"accounts"`
+	APIURL          string                 `json:"apiUrl"`
+	DownloadURL     string                 `json:"downloadUrl"`
+	UploadURL       string                 `json:"uploadUrl"`
+	AccountID       string                 // Primary mail account ID
+	Accounts        map[string]interface{} `json:"accounts"`
+	PrimaryAccounts map[string]string      `json:"primaryAccounts"`
 }
 
 // Request is a JMAP request.
@@ -91,10 +92,16 @@ func (c *Client) GetSession() (*Session, error) {
 		return nil, fmt.Errorf("failed to decode session: %w", err)
 	}
 
-	// Extract first account ID
-	for id := range session.Accounts {
+	// Use primaryAccounts to find the correct mail account (RFC 8620).
+	// On family/team plans, the session may contain multiple accounts.
+	// Falling back to first account only if primaryAccounts is missing.
+	if id, ok := session.PrimaryAccounts[MailCapability]; ok && id != "" {
 		session.AccountID = id
-		break
+	} else {
+		for id := range session.Accounts {
+			session.AccountID = id
+			break
+		}
 	}
 
 	c.session = &session

--- a/internal/jmap/client_test.go
+++ b/internal/jmap/client_test.go
@@ -58,6 +58,36 @@ func TestClient_GetSession(t *testing.T) {
 	assert.Equal(t, "account-123", session.AccountID)
 }
 
+func TestClient_GetSession_UsesPrimaryMailAccount(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	client := newTestClient()
+
+	httpmock.RegisterResponder("GET", "https://api.test.com/jmap/session",
+		httpmock.NewJsonResponderOrPanic(200, map[string]interface{}{
+			"apiUrl":      "https://api.test.com/jmap/api",
+			"downloadUrl": "https://api.test.com/jmap/download",
+			"uploadUrl":   "https://api.test.com/jmap/upload",
+			"accounts": map[string]interface{}{
+				"account-owner": map[string]interface{}{
+					"name": "owner@example.com",
+				},
+				"account-member": map[string]interface{}{
+					"name": "member@example.com",
+				},
+			},
+			"primaryAccounts": map[string]interface{}{
+				MailCapability: "account-member",
+			},
+		}))
+
+	session, err := client.GetSession()
+
+	require.NoError(t, err)
+	assert.Equal(t, "account-member", session.AccountID)
+}
+
 func TestClient_GetSession_Cached(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()


### PR DESCRIPTION
## Problem

On Fastmail family/team plans, the JMAP session returns multiple accounts. The current code picks the first account from a Go map iteration:

```go
for id := range session.Accounts {
    session.AccountID = id
    break
}
```

Go maps have non-deterministic iteration order, so this randomly selects the wrong account. When it picks the plan owner's account instead of the authenticated member's account, all mailbox and email operations fail intermittently ("mailbox with role not found", "email not found").

## Fix

Parse `primaryAccounts` from the JMAP session response (per [[RFC 8620 §2](https://www.rfc-editor.org/rfc/rfc8620#section-2)](https://www.rfc-editor.org/rfc/rfc8620#section-2)) and use the account ID mapped to `urn:ietf:params:jmap:mail`. Falls back to the existing behavior if `primaryAccounts` is missing.

## Testing

All existing tests pass. Verified manually on a family plan with two accounts.