### PR TITLE
fix: use correct identity when sending from non-default address

### DIFF
--- a/internal/jmap/identity.go
+++ b/internal/jmap/identity.go
@@ -3,6 +3,7 @@ package jmap
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // GetIdentities fetches all sender identities.
@@ -60,4 +61,36 @@ func (c *Client) GetDefaultIdentity() (*Identity, error) {
 	}
 
 	return &identities[0], nil
+}
+
+// GetIdentityByEmail finds the identity matching an email address.
+// Handles wildcard identities like "*@domain.com".
+func (c *Client) GetIdentityByEmail(email string) (*Identity, error) {
+	identities, err := c.GetIdentities()
+	if err != nil {
+		return nil, err
+	}
+
+	email = strings.ToLower(email)
+
+	// First pass: exact match
+	for _, id := range identities {
+		if strings.ToLower(id.Email) == email {
+			return &id, nil
+		}
+	}
+
+	// Second pass: wildcard match (*@domain.com)
+	parts := strings.SplitN(email, "@", 2)
+	if len(parts) == 2 {
+		domain := parts[1]
+		wildcard := "*@" + domain
+		for _, id := range identities {
+			if strings.ToLower(id.Email) == wildcard {
+				return &id, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no identity found for %s", email)
 }

--- a/internal/jmap/submission.go
+++ b/internal/jmap/submission.go
@@ -42,6 +42,12 @@ func (c *Client) SendEmail(draftID string) error {
 		return fmt.Errorf("could not find Sent mailbox: %w", err)
 	}
 
+	// Get drafts mailbox to remove email from it
+	draftsMailbox, err := c.GetMailboxByRole("drafts")
+	if err != nil {
+		return fmt.Errorf("could not find Drafts mailbox: %w", err)
+	}
+
 	// Create EmailSubmission and update the email's mailbox in one request
 	request := &Request{
 		Using: []string{CoreCapability, MailCapability, SubmissionCapability},
@@ -58,8 +64,9 @@ func (c *Client) SendEmail(draftID string) error {
 					},
 					"onSuccessUpdateEmail": map[string]interface{}{
 						"#submission": map[string]interface{}{
-							"mailboxIds/" + sentMailbox.ID: true,
-							"keywords/$draft":              nil,
+							"mailboxIds/" + sentMailbox.ID:   true,
+							"mailboxIds/" + draftsMailbox.ID: nil,
+							"keywords/$draft":                nil,
 						},
 					},
 				},

--- a/internal/jmap/submission.go
+++ b/internal/jmap/submission.go
@@ -12,10 +12,28 @@ func (c *Client) SendEmail(draftID string) error {
 		return err
 	}
 
-	// Get identity for sending
-	identity, err := c.GetDefaultIdentity()
+	// Fetch the draft to get its From address
+	draft, err := c.GetEmailByID(draftID)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to fetch draft: %w", err)
+	}
+
+	// Get identity matching the draft's From address
+	var identity *Identity
+	if len(draft.From) > 0 && draft.From[0].Email != "" {
+		identity, err = c.GetIdentityByEmail(draft.From[0].Email)
+		if err != nil {
+			// Fall back to default if no match found
+			identity, err = c.GetDefaultIdentity()
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		identity, err = c.GetDefaultIdentity()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Get sent mailbox


### PR DESCRIPTION
## Summary

**Fix 1: Identity lookup (fixes #3)**
- Fixes sending from non-primary identities which failed with `forbiddenFrom` error
- `SendEmail()` now looks up the identity matching the draft's From address instead of always using the default
- Adds `GetIdentityByEmail()` which handles both exact matches and wildcard identities

**Fix 2: Move sent emails to Sent folder (fixes #5)**
- Sent emails now properly move from Drafts to Sent folder
- The `onSuccessUpdateEmail` was only adding to Sent, not removing from Drafts

## Test plan

- [x] Created drafts with `--from` set to non-primary identities
- [x] Sent successfully using the fixed code
- [x] Verified wildcard identity matching works
- [x] Verified sent emails move from Drafts to Sent folder