### PR TITLE
feat: add email mark read/unread command

### DIFF
--- a/internal/cmd/email/email.go
+++ b/internal/cmd/email/email.go
@@ -23,6 +23,7 @@ func NewCmdEmail(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdArchive(f))
 	cmd.AddCommand(NewCmdMove(f))
 	cmd.AddCommand(NewCmdDelete(f))
+	cmd.AddCommand(NewCmdMark(f))
 
 	return cmd
 }

--- a/internal/cmd/email/mark.go
+++ b/internal/cmd/email/mark.go
@@ -1,0 +1,52 @@
+package email
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdMark creates the email mark command.
+func NewCmdMark(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mark <email-id> <read|unread>",
+		Short: "Mark an email as read or unread",
+		Long:  `Mark an email as read or unread by setting the $seen keyword.`,
+		Example: `  # Mark as read
+  fm email mark M1234567890 read
+
+  # Mark as unread
+  fm email mark M1234567890 unread`,
+		Args: cmdutil.ExactArgs(2, "email ID and state (read/unread) required\n\nUsage: fm email mark <email-id> <read|unread>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMark(f, args[0], args[1])
+		},
+	}
+
+	return cmd
+}
+
+func runMark(f *cmdutil.Factory, emailID, state string) error {
+	var read bool
+	switch state {
+	case "read":
+		read = true
+	case "unread":
+		read = false
+	default:
+		return fmt.Errorf("invalid state %q: must be 'read' or 'unread'", state)
+	}
+
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.MarkRead(emailID, read); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(f.IOStreams.Out, "Marked as %s.\n", state)
+	return nil
+}

--- a/internal/jmap/email.go
+++ b/internal/jmap/email.go
@@ -353,9 +353,12 @@ func (c *Client) MarkRead(emailID string, read bool) error {
 		return err
 	}
 
-	keywords := map[string]bool{}
+	// Use patch syntax to toggle only $seen without affecting other keywords
+	var patch map[string]interface{}
 	if read {
-		keywords["$seen"] = true
+		patch = map[string]interface{}{"keywords/$seen": true}
+	} else {
+		patch = map[string]interface{}{"keywords/$seen": nil}
 	}
 
 	request := &Request{
@@ -366,9 +369,7 @@ func (c *Client) MarkRead(emailID string, read bool) error {
 				map[string]interface{}{
 					"accountId": session.AccountID,
 					"update": map[string]interface{}{
-						emailID: map[string]interface{}{
-							"keywords": keywords,
-						},
+						emailID: patch,
 					},
 				},
 				"markRead",


### PR DESCRIPTION
Adds `fm email mark <id> read|unread` to mark emails as read or unread.

Also fixes the existing MarkRead JMAP function to use patch syntax (`keywords/$seen`) instead of replacing all keywords, which would wipe other keywords like $flagged.