### PR TITLE
feat: add email star/unstar commands

### DIFF
--- a/internal/cmd/email/email.go
+++ b/internal/cmd/email/email.go
@@ -23,6 +23,8 @@ func NewCmdEmail(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdArchive(f))
 	cmd.AddCommand(NewCmdMove(f))
 	cmd.AddCommand(NewCmdDelete(f))
+	cmd.AddCommand(NewCmdStar(f))
+	cmd.AddCommand(NewCmdUnstar(f))
 
 	return cmd
 }

--- a/internal/cmd/email/star.go
+++ b/internal/cmd/email/star.go
@@ -1,0 +1,58 @@
+package email
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdStar creates the email star command.
+func NewCmdStar(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "star <email-id>",
+		Short: "Star (flag) an email",
+		Long:  `Star an email by setting the $flagged keyword.`,
+		Example: `  fm email star M1234567890`,
+		Args: cmdutil.ExactArgs(1, "email ID required\n\nUsage: fm email star <email-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStar(f, args[0], true)
+		},
+	}
+
+	return cmd
+}
+
+// NewCmdUnstar creates the email unstar command.
+func NewCmdUnstar(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unstar <email-id>",
+		Short: "Unstar (unflag) an email",
+		Long:  `Unstar an email by removing the $flagged keyword.`,
+		Example: `  fm email unstar M1234567890`,
+		Args: cmdutil.ExactArgs(1, "email ID required\n\nUsage: fm email unstar <email-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStar(f, args[0], false)
+		},
+	}
+
+	return cmd
+}
+
+func runStar(f *cmdutil.Factory, emailID string, star bool) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.SetFlagged(emailID, star); err != nil {
+		return err
+	}
+
+	if star {
+		fmt.Fprintln(f.IOStreams.Out, "Starred.")
+	} else {
+		fmt.Fprintln(f.IOStreams.Out, "Unstarred.")
+	}
+	return nil
+}

--- a/internal/jmap/email.go
+++ b/internal/jmap/email.go
@@ -384,6 +384,45 @@ func (c *Client) MarkRead(emailID string, read bool) error {
 	return c.checkSetError(resp, 0, emailID)
 }
 
+// SetFlagged stars or unstars an email.
+func (c *Client) SetFlagged(emailID string, flagged bool) error {
+	session, err := c.GetSession()
+	if err != nil {
+		return err
+	}
+
+	// Use patch syntax to toggle only $flagged without affecting other keywords
+	var patch map[string]interface{}
+	if flagged {
+		patch = map[string]interface{}{"keywords/$flagged": true}
+	} else {
+		patch = map[string]interface{}{"keywords/$flagged": nil}
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, MailCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"Email/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"update": map[string]interface{}{
+						emailID: patch,
+					},
+				},
+				"setFlagged",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return err
+	}
+
+	return c.checkSetError(resp, 0, emailID)
+}
+
 // DownloadBlob downloads an attachment blob.
 func (c *Client) DownloadBlob(blobID, name, contentType string) ([]byte, error) {
 	session, err := c.GetSession()


### PR DESCRIPTION
Adds `fm email star <id>` and `fm email unstar <id>` to flag/unflag emails.

Uses the $flagged JMAP keyword with patch syntax to avoid affecting other keywords.