### PR TITLE
feat: add vacation auto-responder commands

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/identity"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/inbox"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/search"
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/vacation"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/version"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
@@ -91,6 +92,7 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(search.NewCmdSearch(f))
 	cmd.AddCommand(folders.NewCmdFolders(f))
 	cmd.AddCommand(identities.NewCmdIdentities(f))
+	cmd.AddCommand(vacation.NewCmdVacation(f))
 
 	// Email subcommands
 	cmd.AddCommand(email.NewCmdEmail(f))

--- a/internal/cmd/vacation/off.go
+++ b/internal/cmd/vacation/off.go
@@ -1,0 +1,37 @@
+package vacation
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdOff creates the vacation off command.
+func NewCmdOff(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "off",
+		Short: "Disable vacation auto-responder",
+		Long:  "Disable the vacation auto-responder.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOff(f)
+		},
+	}
+
+	return cmd
+}
+
+func runOff(f *cmdutil.Factory) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.SetVacationResponse(false, nil, nil, nil, nil); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(f.IOStreams.Out, "Vacation auto-responder disabled.")
+	return nil
+}

--- a/internal/cmd/vacation/on.go
+++ b/internal/cmd/vacation/on.go
@@ -1,0 +1,74 @@
+package vacation
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type onOptions struct {
+	Subject  string
+	Body     string
+	FromDate string
+	ToDate   string
+}
+
+// NewCmdOn creates the vacation on command.
+func NewCmdOn(f *cmdutil.Factory) *cobra.Command {
+	opts := &onOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "on",
+		Short: "Enable vacation auto-responder",
+		Long:  "Enable the vacation auto-responder with an optional message.",
+		Example: `  # Enable with a message
+  fm vacation on --subject "Out of office" --body "I'm away until Monday."
+
+  # Enable with date range
+  fm vacation on --subject "Vacation" --body "Away" --from 2024-12-20 --to 2024-12-31`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOn(f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Subject, "subject", "", "Auto-reply subject line")
+	cmd.Flags().StringVar(&opts.Body, "body", "", "Auto-reply message body")
+	cmd.Flags().StringVar(&opts.FromDate, "from", "", "Start date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&opts.ToDate, "to", "", "End date (YYYY-MM-DD)")
+
+	return cmd
+}
+
+func runOn(f *cmdutil.Factory, opts *onOptions) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	var subject, body, fromDate, toDate *string
+	if opts.Subject != "" {
+		subject = &opts.Subject
+	}
+	if opts.Body != "" {
+		body = &opts.Body
+	}
+	if opts.FromDate != "" {
+		// JMAP expects UTC datetime, convert date to start of day
+		from := opts.FromDate + "T00:00:00Z"
+		fromDate = &from
+	}
+	if opts.ToDate != "" {
+		// JMAP expects UTC datetime, convert date to end of day
+		to := opts.ToDate + "T23:59:59Z"
+		toDate = &to
+	}
+
+	if err := client.SetVacationResponse(true, subject, body, fromDate, toDate); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(f.IOStreams.Out, "Vacation auto-responder enabled.")
+	return nil
+}

--- a/internal/cmd/vacation/status.go
+++ b/internal/cmd/vacation/status.go
@@ -1,0 +1,58 @@
+package vacation
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdStatus creates the vacation status command.
+func NewCmdStatus(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show vacation auto-responder status",
+		Long:  "Display the current vacation auto-responder settings.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(f)
+		},
+	}
+
+	return cmd
+}
+
+func runStatus(f *cmdutil.Factory) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	vacation, err := client.GetVacationResponse()
+	if err != nil {
+		return err
+	}
+
+	out := f.IOStreams.Out
+
+	if vacation.IsEnabled {
+		fmt.Fprintln(out, "Status: ON")
+	} else {
+		fmt.Fprintln(out, "Status: OFF")
+	}
+
+	if vacation.Subject != nil && *vacation.Subject != "" {
+		fmt.Fprintf(out, "Subject: %s\n", *vacation.Subject)
+	}
+	if vacation.TextBody != nil && *vacation.TextBody != "" {
+		fmt.Fprintf(out, "Message:\n%s\n", *vacation.TextBody)
+	}
+	if vacation.FromDate != nil && *vacation.FromDate != "" {
+		fmt.Fprintf(out, "From: %s\n", *vacation.FromDate)
+	}
+	if vacation.ToDate != nil && *vacation.ToDate != "" {
+		fmt.Fprintf(out, "To: %s\n", *vacation.ToDate)
+	}
+
+	return nil
+}

--- a/internal/cmd/vacation/vacation.go
+++ b/internal/cmd/vacation/vacation.go
@@ -1,0 +1,24 @@
+package vacation
+
+import (
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdVacation creates the vacation parent command.
+func NewCmdVacation(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vacation <command>",
+		Short: "Manage vacation auto-responder",
+		Long:  "Get, enable, or disable the vacation auto-responder.",
+		Example: `  $ fm vacation status
+  $ fm vacation on --subject "Out of office" --body "I'm away until Monday."
+  $ fm vacation off`,
+	}
+
+	cmd.AddCommand(NewCmdStatus(f))
+	cmd.AddCommand(NewCmdOn(f))
+	cmd.AddCommand(NewCmdOff(f))
+
+	return cmd
+}

--- a/internal/jmap/client.go
+++ b/internal/jmap/client.go
@@ -163,7 +163,8 @@ func (c *Client) AccountID() (string, error) {
 
 // Standard JMAP capabilities
 var (
-	CoreCapability       = "urn:ietf:params:jmap:core"
-	MailCapability       = "urn:ietf:params:jmap:mail"
-	SubmissionCapability = "urn:ietf:params:jmap:submission"
+	CoreCapability             = "urn:ietf:params:jmap:core"
+	MailCapability             = "urn:ietf:params:jmap:mail"
+	SubmissionCapability       = "urn:ietf:params:jmap:submission"
+	VacationResponseCapability = "urn:ietf:params:jmap:vacationresponse"
 )

--- a/internal/jmap/types.go
+++ b/internal/jmap/types.go
@@ -79,6 +79,17 @@ type Thread struct {
 	EmailIDs []string `json:"emailIds"`
 }
 
+// VacationResponse represents a JMAP vacation auto-responder.
+type VacationResponse struct {
+	ID        string  `json:"id"`
+	IsEnabled bool    `json:"isEnabled"`
+	FromDate  *string `json:"fromDate,omitempty"`
+	ToDate    *string `json:"toDate,omitempty"`
+	Subject   *string `json:"subject,omitempty"`
+	TextBody  *string `json:"textBody,omitempty"`
+	HTMLBody  *string `json:"htmlBody,omitempty"`
+}
+
 // IsUnread returns true if the email hasn't been read.
 func (e *Email) IsUnread() bool {
 	return !e.Keywords["$seen"]

--- a/internal/jmap/vacation.go
+++ b/internal/jmap/vacation.go
@@ -1,0 +1,116 @@
+package jmap
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetVacationResponse fetches the current vacation response settings.
+func (c *Client) GetVacationResponse() (*VacationResponse, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, VacationResponseCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"VacationResponse/get",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"ids":       nil, // Get all (there's only one singleton)
+				},
+				"vacation",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		List []VacationResponse `json:"list"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return nil, fmt.Errorf("failed to parse vacation response: %w", err)
+	}
+
+	if len(result.List) == 0 {
+		return nil, fmt.Errorf("no vacation response found")
+	}
+
+	return &result.List[0], nil
+}
+
+// SetVacationResponse updates the vacation response settings.
+func (c *Client) SetVacationResponse(enabled bool, subject, textBody *string, fromDate, toDate *string) error {
+	session, err := c.GetSession()
+	if err != nil {
+		return err
+	}
+
+	// Get current vacation response to get its ID
+	current, err := c.GetVacationResponse()
+	if err != nil {
+		return err
+	}
+
+	update := map[string]interface{}{
+		"isEnabled": enabled,
+	}
+	if subject != nil {
+		update["subject"] = *subject
+	}
+	if textBody != nil {
+		update["textBody"] = *textBody
+	}
+	if fromDate != nil {
+		update["fromDate"] = *fromDate
+	}
+	if toDate != nil {
+		update["toDate"] = *toDate
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, VacationResponseCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"VacationResponse/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"update": map[string]interface{}{
+						current.ID: update,
+					},
+				},
+				"setVacation",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return err
+	}
+
+	var result struct {
+		Updated    map[string]interface{} `json:"updated"`
+		NotUpdated map[string]struct {
+			Type        string `json:"type"`
+			Description string `json:"description"`
+		} `json:"notUpdated"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return err
+	}
+
+	if e, ok := result.NotUpdated[current.ID]; ok {
+		return fmt.Errorf("%s: %s", e.Type, e.Description)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds `fm vacation status|on|off` to manage the vacation auto-responder.

- `fm vacation status`: show current settings
- `fm vacation on`: enable with optional --subject, --body, --from, --to flags
- `fm vacation off`: disable

Uses the `urn:ietf:params:jmap:vacationresponse` capability.