### PR TITLE
feat: add masked email management commands

### DIFF
--- a/internal/cmd/mask/create.go
+++ b/internal/cmd/mask/create.go
@@ -1,0 +1,56 @@
+package mask
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type createOptions struct {
+	Domain      string
+	Description string
+}
+
+// NewCmdCreate creates the mask create command.
+func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	opts := &createOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new masked email address",
+		Long:  "Create a new masked email address with an optional domain and description.",
+		Example: `  # Create a basic masked email
+  fm mask create
+
+  # Create for a specific domain
+  fm mask create --domain example.com
+
+  # Create with description
+  fm mask create --domain shopping.com --desc "Online store account"`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Domain, "domain", "", "Associate with this domain")
+	cmd.Flags().StringVar(&opts.Description, "desc", "", "Description for the masked email")
+
+	return cmd
+}
+
+func runCreate(f *cmdutil.Factory, opts *createOptions) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	masked, err := client.CreateMaskedEmail(opts.Domain, opts.Description)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(f.IOStreams.Out, "Created: %s\n", masked.Email)
+	return nil
+}

--- a/internal/cmd/mask/list.go
+++ b/internal/cmd/mask/list.go
@@ -1,0 +1,82 @@
+package mask
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
+	"github.com/spf13/cobra"
+)
+
+type listOptions struct {
+	JSON  bool
+	State string
+}
+
+// NewCmdList creates the mask list command.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	opts := &listOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List masked email addresses",
+		Long:  "List all masked email addresses with their status.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(f, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output as JSON")
+	cmd.Flags().StringVar(&opts.State, "state", "", "Filter by state (enabled, disabled, pending)")
+
+	return cmd
+}
+
+func runList(f *cmdutil.Factory, opts *listOptions) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	masks, err := client.GetMaskedEmails()
+	if err != nil {
+		return err
+	}
+
+	// Filter by state if specified
+	if opts.State != "" {
+		var filtered []jmap.MaskedEmail
+		for _, m := range masks {
+			if strings.EqualFold(m.State, opts.State) {
+				filtered = append(filtered, m)
+			}
+		}
+		masks = filtered
+	}
+
+	if opts.JSON {
+		return json.NewEncoder(f.IOStreams.Out).Encode(masks)
+	}
+
+	if len(masks) == 0 {
+		fmt.Fprintln(f.IOStreams.Out, "No masked emails found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(f.IOStreams.Out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "EMAIL\tSTATE\tDOMAIN\tDESCRIPTION")
+	for _, m := range masks {
+		desc := m.Description
+		if len(desc) > 30 {
+			desc = desc[:27] + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", m.Email, m.State, m.ForDomain, desc)
+	}
+	w.Flush()
+
+	return nil
+}

--- a/internal/cmd/mask/mask.go
+++ b/internal/cmd/mask/mask.go
@@ -1,0 +1,27 @@
+package mask
+
+import (
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdMask creates the mask parent command.
+func NewCmdMask(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mask <command>",
+		Short: "Manage masked email addresses",
+		Long:  "Create, list, and manage Fastmail masked email addresses.",
+		Example: `  $ fm mask list
+  $ fm mask create --domain example.com --desc "Shopping site"
+  $ fm mask disable abc123
+  $ fm mask enable abc123`,
+	}
+
+	cmd.AddCommand(NewCmdList(f))
+	cmd.AddCommand(NewCmdCreate(f))
+	cmd.AddCommand(NewCmdEnable(f))
+	cmd.AddCommand(NewCmdDisable(f))
+	cmd.AddCommand(NewCmdDelete(f))
+
+	return cmd
+}

--- a/internal/cmd/mask/state.go
+++ b/internal/cmd/mask/state.go
@@ -1,0 +1,90 @@
+package mask
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdEnable creates the mask enable command.
+func NewCmdEnable(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable <email-or-id>",
+		Short: "Enable a masked email address",
+		Long:  "Enable a disabled masked email address so it receives mail again.",
+		Args:  cmdutil.ExactArgs(1, "masked email address or ID required"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetState(f, args[0], "enabled")
+		},
+	}
+
+	return cmd
+}
+
+// NewCmdDisable creates the mask disable command.
+func NewCmdDisable(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disable <email-or-id>",
+		Short: "Disable a masked email address",
+		Long:  "Disable a masked email address. Mail to this address will be rejected.",
+		Args:  cmdutil.ExactArgs(1, "masked email address or ID required"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetState(f, args[0], "disabled")
+		},
+	}
+
+	return cmd
+}
+
+// NewCmdDelete creates the mask delete command.
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <email-or-id>",
+		Short: "Delete a masked email address",
+		Long:  "Permanently delete a masked email address.",
+		Args:  cmdutil.ExactArgs(1, "masked email address or ID required"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetState(f, args[0], "deleted")
+		},
+	}
+
+	return cmd
+}
+
+func runSetState(f *cmdutil.Factory, emailOrID, state string) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	// If it looks like an email address, find the ID
+	id := emailOrID
+	if len(emailOrID) > 10 && emailOrID[len(emailOrID)-3:] != ".fm" {
+		// Might be an ID already, but let's check if it's an email
+		masks, err := client.GetMaskedEmails()
+		if err != nil {
+			return err
+		}
+		for _, m := range masks {
+			if m.Email == emailOrID {
+				id = m.ID
+				break
+			}
+		}
+	}
+
+	if err := client.SetMaskedEmailState(id, state); err != nil {
+		return err
+	}
+
+	switch state {
+	case "enabled":
+		fmt.Fprintln(f.IOStreams.Out, "Enabled.")
+	case "disabled":
+		fmt.Fprintln(f.IOStreams.Out, "Disabled.")
+	case "deleted":
+		fmt.Fprintln(f.IOStreams.Out, "Deleted.")
+	}
+	return nil
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/identities"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/identity"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/inbox"
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/mask"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/search"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/version"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
@@ -91,6 +92,7 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(search.NewCmdSearch(f))
 	cmd.AddCommand(folders.NewCmdFolders(f))
 	cmd.AddCommand(identities.NewCmdIdentities(f))
+	cmd.AddCommand(mask.NewCmdMask(f))
 
 	// Email subcommands
 	cmd.AddCommand(email.NewCmdEmail(f))

--- a/internal/jmap/client.go
+++ b/internal/jmap/client.go
@@ -167,3 +167,8 @@ var (
 	MailCapability       = "urn:ietf:params:jmap:mail"
 	SubmissionCapability = "urn:ietf:params:jmap:submission"
 )
+
+// Fastmail extension capabilities
+var (
+	MaskedEmailCapability = "https://www.fastmail.com/dev/maskedemail"
+)

--- a/internal/jmap/maskedemail.go
+++ b/internal/jmap/maskedemail.go
@@ -1,0 +1,158 @@
+package jmap
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetMaskedEmails fetches all masked email addresses.
+func (c *Client) GetMaskedEmails() ([]MaskedEmail, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, MaskedEmailCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"MaskedEmail/get",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"ids":       nil, // Get all
+				},
+				"maskedEmails",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		List []MaskedEmail `json:"list"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return nil, fmt.Errorf("failed to parse masked emails: %w", err)
+	}
+
+	return result.List, nil
+}
+
+// CreateMaskedEmail creates a new masked email address.
+func (c *Client) CreateMaskedEmail(forDomain, description string) (*MaskedEmail, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	create := map[string]interface{}{
+		"state": "enabled",
+	}
+	if forDomain != "" {
+		create["forDomain"] = forDomain
+	}
+	if description != "" {
+		create["description"] = description
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, MaskedEmailCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"MaskedEmail/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"create": map[string]interface{}{
+						"new": create,
+					},
+				},
+				"createMasked",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Created map[string]MaskedEmail `json:"created"`
+		NotCreated map[string]struct {
+			Type        string `json:"type"`
+			Description string `json:"description"`
+		} `json:"notCreated"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return nil, err
+	}
+
+	if e, ok := result.NotCreated["new"]; ok {
+		return nil, fmt.Errorf("%s: %s", e.Type, e.Description)
+	}
+
+	if created, ok := result.Created["new"]; ok {
+		return &created, nil
+	}
+
+	return nil, fmt.Errorf("failed to create masked email: no result returned")
+}
+
+// SetMaskedEmailState updates a masked email's state (enabled, disabled).
+func (c *Client) SetMaskedEmailState(id, state string) error {
+	session, err := c.GetSession()
+	if err != nil {
+		return err
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, MaskedEmailCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"MaskedEmail/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"update": map[string]interface{}{
+						id: map[string]interface{}{
+							"state": state,
+						},
+					},
+				},
+				"updateMasked",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return err
+	}
+
+	var result struct {
+		Updated    map[string]interface{} `json:"updated"`
+		NotUpdated map[string]struct {
+			Type        string `json:"type"`
+			Description string `json:"description"`
+		} `json:"notUpdated"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return err
+	}
+
+	if e, ok := result.NotUpdated[id]; ok {
+		return fmt.Errorf("%s: %s", e.Type, e.Description)
+	}
+
+	return nil
+}
+
+// DeleteMaskedEmail deletes a masked email (sets state to deleted).
+func (c *Client) DeleteMaskedEmail(id string) error {
+	return c.SetMaskedEmailState(id, "deleted")
+}

--- a/internal/jmap/types.go
+++ b/internal/jmap/types.go
@@ -79,6 +79,19 @@ type Thread struct {
 	EmailIDs []string `json:"emailIds"`
 }
 
+// MaskedEmail represents a Fastmail masked email address.
+type MaskedEmail struct {
+	ID            string  `json:"id"`
+	Email         string  `json:"email"`
+	State         string  `json:"state"` // pending, enabled, disabled, deleted
+	ForDomain     string  `json:"forDomain,omitempty"`
+	Description   string  `json:"description,omitempty"`
+	URL           string  `json:"url,omitempty"`
+	LastMessageAt *string `json:"lastMessageAt,omitempty"`
+	CreatedAt     string  `json:"createdAt,omitempty"`
+	CreatedBy     string  `json:"createdBy,omitempty"`
+}
+
 // IsUnread returns true if the email hasn't been read.
 func (e *Email) IsUnread() bool {
 	return !e.Keywords["$seen"]


### PR DESCRIPTION
Adds `fm mask list|create|enable|disable|delete` to manage Fastmail masked emails.

- `fm mask list`: list all masked addresses with optional --state filter
- `fm mask create`: create new masked address with optional --domain and --desc
- `fm mask enable/disable`: toggle state
- `fm mask delete`: permanently delete

Uses the Fastmail proprietary `https://www.fastmail.com/dev/maskedemail` extension.