### PR TITLE
feat: add email label command for managing keywords

### DIFF
--- a/internal/cmd/email/email.go
+++ b/internal/cmd/email/email.go
@@ -23,6 +23,7 @@ func NewCmdEmail(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdArchive(f))
 	cmd.AddCommand(NewCmdMove(f))
 	cmd.AddCommand(NewCmdDelete(f))
+	cmd.AddCommand(NewCmdLabel(f))
 
 	return cmd
 }

--- a/internal/cmd/email/label.go
+++ b/internal/cmd/email/label.go
@@ -1,0 +1,88 @@
+package email
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdLabel creates the email label command.
+func NewCmdLabel(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label <email-id> <add|remove|list> [label]",
+		Short: "Manage labels (keywords) on an email",
+		Long: `Add, remove, or list labels (keywords) on an email.
+
+Labels in JMAP are called "keywords". Standard keywords start with $
+(like $seen, $flagged, $draft). Custom labels can be any string.`,
+		Example: `  # List labels on an email
+  fm email label M1234567890 list
+
+  # Add a custom label
+  fm email label M1234567890 add important
+
+  # Remove a label
+  fm email label M1234567890 remove important`,
+		Args: cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLabel(f, args)
+		},
+	}
+
+	return cmd
+}
+
+func runLabel(f *cmdutil.Factory, args []string) error {
+	emailID := args[0]
+	action := strings.ToLower(args[1])
+
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	switch action {
+	case "list":
+		keywords, err := client.GetKeywords(emailID)
+		if err != nil {
+			return err
+		}
+		if len(keywords) == 0 {
+			fmt.Fprintln(f.IOStreams.Out, "No labels.")
+			return nil
+		}
+		sort.Strings(keywords)
+		for _, k := range keywords {
+			fmt.Fprintln(f.IOStreams.Out, k)
+		}
+		return nil
+
+	case "add":
+		if len(args) < 3 {
+			return fmt.Errorf("label name required for add")
+		}
+		label := args[2]
+		if err := client.SetKeyword(emailID, label, true); err != nil {
+			return err
+		}
+		fmt.Fprintf(f.IOStreams.Out, "Added label: %s\n", label)
+		return nil
+
+	case "remove":
+		if len(args) < 3 {
+			return fmt.Errorf("label name required for remove")
+		}
+		label := args[2]
+		if err := client.SetKeyword(emailID, label, false); err != nil {
+			return err
+		}
+		fmt.Fprintf(f.IOStreams.Out, "Removed label: %s\n", label)
+		return nil
+
+	default:
+		return fmt.Errorf("unknown action %q: use list, add, or remove", action)
+	}
+}

--- a/internal/jmap/email.go
+++ b/internal/jmap/email.go
@@ -384,6 +384,58 @@ func (c *Client) MarkRead(emailID string, read bool) error {
 	return c.checkSetError(resp, 0, emailID)
 }
 
+// SetKeyword adds or removes a keyword (label) on an email.
+func (c *Client) SetKeyword(emailID, keyword string, set bool) error {
+	session, err := c.GetSession()
+	if err != nil {
+		return err
+	}
+
+	var patch map[string]interface{}
+	if set {
+		patch = map[string]interface{}{"keywords/" + keyword: true}
+	} else {
+		patch = map[string]interface{}{"keywords/" + keyword: nil}
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, MailCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"Email/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"update": map[string]interface{}{
+						emailID: patch,
+					},
+				},
+				"setKeyword",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return err
+	}
+
+	return c.checkSetError(resp, 0, emailID)
+}
+
+// GetKeywords returns all keywords on an email.
+func (c *Client) GetKeywords(emailID string) ([]string, error) {
+	email, err := c.GetEmailByID(emailID)
+	if err != nil {
+		return nil, err
+	}
+
+	var keywords []string
+	for k := range email.Keywords {
+		keywords = append(keywords, k)
+	}
+	return keywords, nil
+}
+
 // DownloadBlob downloads an attachment blob.
 func (c *Client) DownloadBlob(blobID, name, contentType string) ([]byte, error) {
 	session, err := c.GetSession()


### PR DESCRIPTION
Adds `fm email label <id> list|add|remove [label]` to manage keywords.

- `list`: show all keywords on email
- `add <label>`: add a custom keyword
- `remove <label>`: remove a keyword

Works with both standard ($seen, $flagged) and custom keywords.