### PR TITLE
feat: add delayed send (undo-send) support

### DIFF
--- a/internal/cmd/draft/send.go
+++ b/internal/cmd/draft/send.go
@@ -13,6 +13,7 @@ import (
 type sendOptions struct {
 	Yes    bool
 	Unsafe bool
+	Hold   int // Seconds to hold before sending (undo window)
 }
 
 // NewCmdSend creates the draft send command.
@@ -27,6 +28,10 @@ func NewCmdSend(f *cmdutil.Factory) *cobra.Command {
 This is a critical action and requires confirmation. The email will be
 sent immediately and moved to your Sent folder.
 
+Use --hold to delay sending for a number of seconds. During this window,
+you can cancel with "fm email cancel <submission-id>". This enables
+undo-send functionality.
+
 In non-interactive mode (scripts, AI), this command is blocked unless
 --unsafe is specified. This prevents accidental sending by automated tools.`,
 		Example: `  # Send with confirmation prompt
@@ -34,6 +39,9 @@ In non-interactive mode (scripts, AI), this command is blocked unless
 
   # Send without confirmation
   fm draft send M1234567890 --yes
+
+  # Send with 20-second undo window
+  fm draft send M1234567890 --hold 20
 
   # Send in script/AI mode (requires explicit unsafe flag)
   fm draft send M1234567890 --unsafe --yes`,
@@ -45,6 +53,7 @@ In non-interactive mode (scripts, AI), this command is blocked unless
 
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&opts.Unsafe, "unsafe", false, "Allow in non-interactive mode")
+	cmd.Flags().IntVar(&opts.Hold, "hold", 0, "Seconds to hold before sending (undo window)")
 
 	return cmd
 }
@@ -93,11 +102,17 @@ func runSend(f *cmdutil.Factory, opts *sendOptions, draftID string) error {
 		}
 	}
 
-	if err := client.SendEmail(draftID); err != nil {
+	sendOpts := &jmap.SendOptions{HoldFor: opts.Hold}
+	submissionID, err := client.SendEmail(draftID, sendOpts)
+	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(f.IOStreams.Out, "Email sent successfully.")
+	if opts.Hold > 0 {
+		fmt.Fprintf(f.IOStreams.Out, "Email queued (hold %ds). Cancel: fm email cancel %s\n", opts.Hold, submissionID)
+	} else {
+		fmt.Fprintln(f.IOStreams.Out, "Email sent successfully.")
+	}
 	return nil
 }
 

--- a/internal/cmd/email/cancel.go
+++ b/internal/cmd/email/cancel.go
@@ -1,0 +1,42 @@
+package email
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdCancel creates the email cancel command.
+func NewCmdCancel(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel <submission-id>",
+		Short: "Cancel a pending email (undo send)",
+		Long: `Cancel a pending email submission before it's sent.
+
+This only works for emails sent with --hold that haven't been
+released yet. The submission ID is shown when using --hold.`,
+		Example: `  # Cancel a pending send
+  fm email cancel ES1234567890`,
+		Args: cmdutil.ExactArgs(1, "submission ID required"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCancel(f, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runCancel(f *cmdutil.Factory, submissionID string) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.CancelSubmission(submissionID); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(f.IOStreams.Out, "Send canceled.")
+	return nil
+}

--- a/internal/cmd/email/email.go
+++ b/internal/cmd/email/email.go
@@ -23,6 +23,8 @@ func NewCmdEmail(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdArchive(f))
 	cmd.AddCommand(NewCmdMove(f))
 	cmd.AddCommand(NewCmdDelete(f))
+	cmd.AddCommand(NewCmdPending(f))
+	cmd.AddCommand(NewCmdCancel(f))
 
 	return cmd
 }

--- a/internal/cmd/email/pending.go
+++ b/internal/cmd/email/pending.go
@@ -1,0 +1,53 @@
+package email
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdPending creates the email pending command.
+func NewCmdPending(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pending",
+		Short: "List pending email submissions",
+		Long: `List emails that are queued but not yet sent.
+
+These are emails sent with --hold that can still be canceled.`,
+		Example: `  fm email pending`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPending(f)
+		},
+	}
+
+	return cmd
+}
+
+func runPending(f *cmdutil.Factory) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	submissions, err := client.GetPendingSubmissions()
+	if err != nil {
+		return err
+	}
+
+	if len(submissions) == 0 {
+		fmt.Fprintln(f.IOStreams.Out, "No pending submissions.")
+		return nil
+	}
+
+	for _, s := range submissions {
+		sendAt := "unknown"
+		if s.SendAt != nil {
+			sendAt = s.SendAt.Local().Format("15:04:05")
+		}
+		fmt.Fprintf(f.IOStreams.Out, "%s  email:%s  sends:%s\n", s.ID, s.EmailID, sendAt)
+	}
+
+	return nil
+}

--- a/internal/jmap/submission.go
+++ b/internal/jmap/submission.go
@@ -3,25 +3,60 @@ package jmap
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
-// SendEmail sends a draft email.
-func (c *Client) SendEmail(draftID string) error {
+// SendOptions configures email sending behavior.
+type SendOptions struct {
+	HoldFor int // Seconds to hold before sending (0 = immediate)
+}
+
+// EmailSubmission represents a pending or completed email submission.
+type EmailSubmission struct {
+	ID         string     `json:"id"`
+	EmailID    string     `json:"emailId"`
+	IdentityID string     `json:"identityId"`
+	SendAt     *time.Time `json:"sendAt"`
+	UndoStatus string     `json:"undoStatus"` // pending, final, canceled
+}
+
+// SendEmail sends a draft email with optional hold for undo.
+// Returns the submission ID (useful for cancellation if holdFor > 0).
+func (c *Client) SendEmail(draftID string, opts *SendOptions) (string, error) {
 	session, err := c.GetSession()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Get identity for sending
 	identity, err := c.GetDefaultIdentity()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Get sent mailbox
 	sentMailbox, err := c.GetMailboxByRole("sent")
 	if err != nil {
-		return fmt.Errorf("could not find Sent mailbox: %w", err)
+		return "", fmt.Errorf("could not find Sent mailbox: %w", err)
+	}
+
+	// Build submission object
+	submission := map[string]interface{}{
+		"emailId":    draftID,
+		"identityId": identity.ID,
+	}
+
+	// Add holdFor for delayed/undo send
+	if opts != nil && opts.HoldFor > 0 {
+		submission["envelope"] = map[string]interface{}{
+			"mailFrom": map[string]interface{}{
+				"email": identity.Email,
+				"parameters": map[string]interface{}{
+					"holdFor": opts.HoldFor,
+				},
+			},
+			// ponytail: rcptTo populated by server from email headers
+		}
 	}
 
 	// Create EmailSubmission and update the email's mailbox in one request
@@ -33,10 +68,7 @@ func (c *Client) SendEmail(draftID string) error {
 				map[string]interface{}{
 					"accountId": session.AccountID,
 					"create": map[string]interface{}{
-						"submission": map[string]interface{}{
-							"emailId":    draftID,
-							"identityId": identity.ID,
-						},
+						"submission": submission,
 					},
 					"onSuccessUpdateEmail": map[string]interface{}{
 						"#submission": map[string]interface{}{
@@ -52,11 +84,13 @@ func (c *Client) SendEmail(draftID string) error {
 
 	resp, err := c.MakeRequest(request)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var result struct {
-		Created map[string]interface{} `json:"created"`
+		Created map[string]struct {
+			ID string `json:"id"`
+		} `json:"created"`
 		NotCreated map[string]struct {
 			Type        string `json:"type"`
 			Description string `json:"description"`
@@ -64,15 +98,116 @@ func (c *Client) SendEmail(draftID string) error {
 	}
 
 	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
-		return err
+		return "", err
 	}
 
 	if e, ok := result.NotCreated["submission"]; ok {
-		return fmt.Errorf("failed to send email: %s - %s", e.Type, e.Description)
+		return "", fmt.Errorf("failed to send email: %s - %s", e.Type, e.Description)
 	}
 
-	if _, ok := result.Created["submission"]; !ok {
-		return fmt.Errorf("failed to send email: no submission created")
+	created, ok := result.Created["submission"]
+	if !ok {
+		return "", fmt.Errorf("failed to send email: no submission created")
+	}
+
+	return created.ID, nil
+}
+
+// GetPendingSubmissions returns submissions that haven't been sent yet.
+func (c *Client) GetPendingSubmissions() ([]EmailSubmission, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, MailCapability, SubmissionCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"EmailSubmission/query",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"filter": map[string]interface{}{
+						"undoStatus": "pending",
+					},
+				},
+				"query",
+			},
+			{
+				"EmailSubmission/get",
+				map[string]interface{}{
+					"accountId":  session.AccountID,
+					"#ids":       map[string]interface{}{"resultOf": "query", "name": "EmailSubmission/query", "path": "/ids"},
+					"properties": []string{"id", "emailId", "identityId", "sendAt", "undoStatus"},
+				},
+				"get",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.MethodResponses) < 2 {
+		return nil, fmt.Errorf("invalid response")
+	}
+
+	var result struct {
+		List []EmailSubmission `json:"list"`
+	}
+	if err := json.Unmarshal(resp.MethodResponses[1][1], &result); err != nil {
+		return nil, err
+	}
+
+	return result.List, nil
+}
+
+// CancelSubmission cancels a pending email submission (undo send).
+func (c *Client) CancelSubmission(submissionID string) error {
+	session, err := c.GetSession()
+	if err != nil {
+		return err
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, MailCapability, SubmissionCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"EmailSubmission/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"update": map[string]interface{}{
+						submissionID: map[string]interface{}{
+							"undoStatus": "canceled",
+						},
+					},
+				},
+				"cancel",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return err
+	}
+
+	var result struct {
+		Updated    map[string]interface{} `json:"updated"`
+		NotUpdated map[string]struct {
+			Type        string `json:"type"`
+			Description string `json:"description"`
+		} `json:"notUpdated"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return err
+	}
+
+	if e, ok := result.NotUpdated[submissionID]; ok {
+		return fmt.Errorf("failed to cancel: %s - %s", e.Type, e.Description)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Add --hold <seconds> flag to fm draft send for undo window
- Add fm email pending to list queued submissions  
- Add fm email cancel <submission-id> to cancel pending sends
- Uses JMAP holdFor parameter (server-side delay via FUTURERELEASE RFC 4865)

## Usage

    # Send with 20-second undo window
    fm draft send M123 --hold 20
    # Output: Email queued (hold 20s). Cancel: fm email cancel ES456

    # List pending sends
    fm email pending

    # Cancel before it sends
    fm email cancel ES456

## Implementation

Uses Fastmail server-side holdFor support in EmailSubmission/set envelope parameters. No local daemon needed - the server holds the email and releases it after the hold period. Cancellation sets undoStatus: canceled on the submission.