### PR TITLE
feat: add contacts management

### DIFF
--- a/internal/cmd/contacts/contacts.go
+++ b/internal/cmd/contacts/contacts.go
@@ -1,0 +1,28 @@
+package contacts
+
+import (
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdContacts creates the contacts parent command.
+func NewCmdContacts(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "contacts <command>",
+		Short: "Manage contacts",
+		Long:  "List, search, create, and delete contacts.",
+		Example: `  $ fm contacts list
+  $ fm contacts show abc123
+  $ fm contacts search "John"
+  $ fm contacts create --name "John Doe" --email john@example.com`,
+		GroupID: "contacts",
+	}
+
+	cmd.AddCommand(NewCmdList(f))
+	cmd.AddCommand(NewCmdShow(f))
+	cmd.AddCommand(NewCmdSearch(f))
+	cmd.AddCommand(NewCmdCreate(f))
+	cmd.AddCommand(NewCmdDelete(f))
+
+	return cmd
+}

--- a/internal/cmd/contacts/create.go
+++ b/internal/cmd/contacts/create.go
@@ -1,0 +1,84 @@
+package contacts
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
+	"github.com/spf13/cobra"
+)
+
+type createOptions struct {
+	Name  string
+	Email string
+	Phone string
+	Org   string
+}
+
+// NewCmdCreate creates the contacts create command.
+func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	opts := &createOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new contact",
+		Long:  "Create a new contact with name, email, phone, and organization.",
+		Example: `  # Create a contact with name only
+  fm contacts create --name "John Doe"
+
+  # Create a contact with all fields
+  fm contacts create --name "John Doe" --email john@example.com --phone "+1-555-1234" --org "Acme Inc"`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Name, "name", "", "Contact name (required)")
+	cmd.Flags().StringVar(&opts.Email, "email", "", "Email address")
+	cmd.Flags().StringVar(&opts.Phone, "phone", "", "Phone number")
+	cmd.Flags().StringVar(&opts.Org, "org", "", "Organization name")
+
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runCreate(f *cmdutil.Factory, opts *createOptions) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	contact := &jmap.ContactCard{
+		Name: &jmap.ContactName{
+			Full: opts.Name,
+		},
+	}
+
+	if opts.Email != "" {
+		contact.Emails = map[string]jmap.ContactEmail{
+			"email1": {Address: opts.Email, Label: "personal"},
+		}
+	}
+
+	if opts.Phone != "" {
+		contact.Phones = map[string]jmap.ContactPhone{
+			"phone1": {Number: opts.Phone, Label: "mobile"},
+		}
+	}
+
+	if opts.Org != "" {
+		contact.Orgs = map[string]jmap.ContactOrg{
+			"org1": {Name: opts.Org},
+		}
+	}
+
+	contactID, err := client.CreateContact(contact)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(f.IOStreams.Out, "Created contact: %s\n", contactID)
+	return nil
+}

--- a/internal/cmd/contacts/delete.go
+++ b/internal/cmd/contacts/delete.go
@@ -1,0 +1,89 @@
+package contacts
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type deleteOptions struct {
+	Yes    bool
+	Unsafe bool
+}
+
+// NewCmdDelete creates the contacts delete command.
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	opts := &deleteOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "delete <contact-id>",
+		Short: "Delete a contact",
+		Long: `Delete a contact from your address book.
+
+This action requires confirmation unless --yes is provided.
+In non-interactive mode (scripts, AI), this command is blocked unless --unsafe is specified.`,
+		Example: `  # Delete with confirmation prompt
+  fm contacts delete abc123
+
+  # Delete without confirmation
+  fm contacts delete abc123 --yes`,
+		Args: cmdutil.ExactArgs(1, "contact ID required\n\nUsage: fm contacts delete <contact-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDelete(f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Unsafe, "unsafe", false, "Allow in non-interactive mode")
+
+	return cmd
+}
+
+func runDelete(f *cmdutil.Factory, opts *deleteOptions, contactID string) error {
+	// Check safe mode
+	if f.IOStreams.IsSafeMode() && !opts.Unsafe {
+		return &cmdutil.SafeModeError{Command: "contacts delete"}
+	}
+
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	// Require confirmation unless --yes
+	if !opts.Yes && f.IOStreams.IsInteractive() {
+		// Get contact info for confirmation
+		contact, err := client.GetContact(contactID)
+		if err != nil {
+			return err
+		}
+
+		name := "(no name)"
+		if contact.Name != nil && contact.Name.Full != "" {
+			name = contact.Name.Full
+		}
+
+		fmt.Fprintf(f.IOStreams.ErrOut, "Contact: %s\n", name)
+		fmt.Fprintf(f.IOStreams.ErrOut, "Delete this contact? [y/N] ")
+
+		scanner := bufio.NewScanner(f.IOStreams.In)
+		response := ""
+		if scanner.Scan() {
+			response = scanner.Text()
+		}
+
+		if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(response)), "y") {
+			return cmdutil.CancelError
+		}
+	}
+
+	if err := client.DeleteContact(contactID); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(f.IOStreams.Out, "Contact deleted.")
+	return nil
+}

--- a/internal/cmd/contacts/list.go
+++ b/internal/cmd/contacts/list.go
@@ -1,0 +1,88 @@
+package contacts
+
+import (
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
+	"github.com/spf13/cobra"
+)
+
+type listOptions struct {
+	Limit int
+}
+
+// NewCmdList creates the contacts list command.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	opts := &listOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List contacts",
+		Long:  "List contacts in your address book.",
+		Example: `  # List first 50 contacts
+  fm contacts list
+
+  # List first 100 contacts
+  fm contacts list --limit 100`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(f, opts)
+		},
+	}
+
+	cmd.Flags().IntVar(&opts.Limit, "limit", 50, "Maximum number of contacts to return")
+
+	return cmd
+}
+
+func runList(f *cmdutil.Factory, opts *listOptions) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	contacts, err := client.GetContacts(opts.Limit)
+	if err != nil {
+		return err
+	}
+
+	return outputContacts(f, contacts)
+}
+
+func outputContacts(f *cmdutil.Factory, contacts []jmap.ContactCard) error {
+	out := f.IOStreams.Out
+
+	if len(contacts) == 0 {
+		fmt.Fprintln(out, "No contacts found.")
+		return nil
+	}
+
+	for _, c := range contacts {
+		name := getContactName(&c)
+		email := getPrimaryEmail(&c)
+		fmt.Fprintf(out, "%-20s  %-30s  %s\n", c.ID, name, email)
+	}
+
+	return nil
+}
+
+// getContactName returns the full name from a ContactCard.
+func getContactName(c *jmap.ContactCard) string {
+	if c.Name == nil {
+		return ""
+	}
+	return c.Name.Full
+}
+
+// getPrimaryEmail returns the first/preferred email from a ContactCard.
+func getPrimaryEmail(c *jmap.ContactCard) string {
+	if len(c.Emails) == 0 {
+		return ""
+	}
+	// Return first email found (maps don't have order, but typically there's only one)
+	for _, email := range c.Emails {
+		return email.Address
+	}
+	return ""
+}

--- a/internal/cmd/contacts/search.go
+++ b/internal/cmd/contacts/search.go
@@ -1,0 +1,48 @@
+package contacts
+
+import (
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type searchOptions struct {
+	Limit int
+}
+
+// NewCmdSearch creates the contacts search command.
+func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
+	opts := &searchOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search contacts",
+		Long:  "Search contacts by name, email, or other fields.",
+		Example: `  # Search for contacts named John
+  fm contacts search "John"
+
+  # Search with custom limit
+  fm contacts search "example.com" --limit 20`,
+		Args: cmdutil.ExactArgs(1, "search query required\n\nUsage: fm contacts search <query>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSearch(f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().IntVar(&opts.Limit, "limit", 50, "Maximum number of contacts to return")
+
+	return cmd
+}
+
+func runSearch(f *cmdutil.Factory, opts *searchOptions, query string) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	contacts, err := client.SearchContacts(query, opts.Limit)
+	if err != nil {
+		return err
+	}
+
+	return outputContacts(f, contacts)
+}

--- a/internal/cmd/contacts/show.go
+++ b/internal/cmd/contacts/show.go
@@ -1,0 +1,97 @@
+package contacts
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdShow creates the contacts show command.
+func NewCmdShow(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <contact-id>",
+		Short: "Show contact details",
+		Long:  "Display full details of a contact including all emails, phones, organization, and notes.",
+		Example: `  fm contacts show abc123`,
+		Args:  cmdutil.ExactArgs(1, "contact ID required\n\nUsage: fm contacts show <contact-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShow(f, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runShow(f *cmdutil.Factory, contactID string) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	contact, err := client.GetContact(contactID)
+	if err != nil {
+		return err
+	}
+
+	return printContact(f, contact)
+}
+
+func printContact(f *cmdutil.Factory, c *jmap.ContactCard) error {
+	out := f.IOStreams.Out
+	sep := strings.Repeat("-", 50)
+
+	fmt.Fprintln(out, sep)
+	fmt.Fprintf(out, "ID:           %s\n", c.ID)
+
+	name := ""
+	if c.Name != nil {
+		name = c.Name.Full
+	}
+	fmt.Fprintf(out, "Name:         %s\n", name)
+
+	if len(c.Emails) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Emails:")
+		for key, email := range c.Emails {
+			label := email.Label
+			if label == "" {
+				label = key
+			}
+			fmt.Fprintf(out, "  %-10s  %s\n", label, email.Address)
+		}
+	}
+
+	if len(c.Phones) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Phones:")
+		for key, phone := range c.Phones {
+			label := phone.Label
+			if label == "" {
+				label = key
+			}
+			fmt.Fprintf(out, "  %-10s  %s\n", label, phone.Number)
+		}
+	}
+
+	if len(c.Orgs) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Organizations:")
+		for _, org := range c.Orgs {
+			fmt.Fprintf(out, "  %s\n", org.Name)
+		}
+	}
+
+	if len(c.Notes) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Notes:")
+		for _, note := range c.Notes {
+			fmt.Fprintln(out, note.Note)
+		}
+	}
+
+	fmt.Fprintln(out, sep)
+	return nil
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/auth"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/completion"
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/contacts"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/draft"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/email"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/folder"
@@ -79,6 +80,10 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 		Title: "Identity commands",
 	})
 	cmd.AddGroup(&cobra.Group{
+		ID:    "contacts",
+		Title: "Contacts commands",
+	})
+	cmd.AddGroup(&cobra.Group{
 		ID:    "utility",
 		Title: "Utility commands",
 	})
@@ -103,6 +108,9 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 
 	// Identity subcommands
 	cmd.AddCommand(identity.NewCmdIdentity(f))
+
+	// Contacts subcommands
+	cmd.AddCommand(contacts.NewCmdContacts(f))
 
 	// Utility commands
 	cmd.AddCommand(version.NewCmdVersion(f, Version))

--- a/internal/jmap/contacts.go
+++ b/internal/jmap/contacts.go
@@ -1,0 +1,311 @@
+package jmap
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ContactsCapability is the JMAP capability for contacts.
+const ContactsCapability = "urn:ietf:params:jmap:contacts"
+
+// ContactCard represents a JSContact ContactCard (RFC 9553).
+type ContactCard struct {
+	ID      string                   `json:"id,omitempty"`
+	Name    *ContactName             `json:"name,omitempty"`
+	Emails  map[string]ContactEmail  `json:"emails,omitempty"`
+	Phones  map[string]ContactPhone  `json:"phones,omitempty"`
+	Orgs    map[string]ContactOrg    `json:"organizations,omitempty"`
+	Notes   map[string]ContactNote   `json:"notes,omitempty"`
+}
+
+// ContactName holds name components.
+type ContactName struct {
+	Full       string       `json:"full,omitempty"`
+	Components []NameComponent `json:"components,omitempty"`
+}
+
+// NameComponent is a single name part (given, surname, etc).
+type NameComponent struct {
+	Kind  string `json:"kind"`  // "given", "surname", etc.
+	Value string `json:"value"`
+}
+
+// ContactEmail represents a contact email address.
+type ContactEmail struct {
+	Address string `json:"address"`
+	Label   string `json:"label,omitempty"`
+	Pref    int    `json:"pref,omitempty"`
+}
+
+// ContactPhone represents a contact phone number.
+type ContactPhone struct {
+	Number string `json:"number"`
+	Label  string `json:"label,omitempty"`
+	Pref   int    `json:"pref,omitempty"`
+}
+
+// ContactOrg represents an organization.
+type ContactOrg struct {
+	Name string `json:"name"`
+}
+
+// ContactNote represents a note on a contact.
+type ContactNote struct {
+	Note string `json:"note"`
+}
+
+// GetContacts fetches contacts up to the given limit.
+func (c *Client) GetContacts(limit int) ([]ContactCard, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 {
+		limit = 100
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, ContactsCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"ContactCard/query",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"limit":     limit,
+				},
+				"query",
+			},
+			{
+				"ContactCard/get",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"#ids":      map[string]interface{}{"resultOf": "query", "name": "ContactCard/query", "path": "/ids"},
+				},
+				"contacts",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.parseContactsFromResponse(resp, 1)
+}
+
+// GetContact fetches a single contact by ID.
+func (c *Client) GetContact(id string) (*ContactCard, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, ContactsCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"ContactCard/get",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"ids":       []string{id},
+				},
+				"contact",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	contacts, err := c.parseContactsFromResponse(resp, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(contacts) == 0 {
+		return nil, fmt.Errorf("contact with ID '%s' not found", id)
+	}
+
+	return &contacts[0], nil
+}
+
+// SearchContacts searches contacts by text query.
+func (c *Client) SearchContacts(query string, limit int) ([]ContactCard, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 {
+		limit = 30
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, ContactsCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"ContactCard/query",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"filter": map[string]interface{}{
+						"text": query,
+					},
+					"limit": limit,
+				},
+				"query",
+			},
+			{
+				"ContactCard/get",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"#ids":      map[string]interface{}{"resultOf": "query", "name": "ContactCard/query", "path": "/ids"},
+				},
+				"contacts",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.parseContactsFromResponse(resp, 1)
+}
+
+// CreateContact creates a new contact and returns its ID.
+func (c *Client) CreateContact(card *ContactCard) (string, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return "", err
+	}
+
+	// Build the contact data (omit ID, server assigns it)
+	contactData := map[string]interface{}{}
+	if card.Name != nil {
+		contactData["name"] = card.Name
+	}
+	if card.Emails != nil {
+		contactData["emails"] = card.Emails
+	}
+	if card.Phones != nil {
+		contactData["phones"] = card.Phones
+	}
+	if card.Orgs != nil {
+		contactData["organizations"] = card.Orgs
+	}
+	if card.Notes != nil {
+		contactData["notes"] = card.Notes
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, ContactsCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"ContactCard/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"create": map[string]interface{}{
+						"newContact": contactData,
+					},
+				},
+				"createContact",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		Created map[string]struct {
+			ID string `json:"id"`
+		} `json:"created"`
+		NotCreated map[string]struct {
+			Type        string `json:"type"`
+			Description string `json:"description"`
+		} `json:"notCreated"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return "", err
+	}
+
+	if e, ok := result.NotCreated["newContact"]; ok {
+		return "", fmt.Errorf("failed to create contact: %s", e.Description)
+	}
+
+	if created, ok := result.Created["newContact"]; ok {
+		return created.ID, nil
+	}
+
+	return "", fmt.Errorf("failed to create contact: no ID returned")
+}
+
+// DeleteContact deletes a contact by ID.
+func (c *Client) DeleteContact(id string) error {
+	session, err := c.GetSession()
+	if err != nil {
+		return err
+	}
+
+	request := &Request{
+		Using: []string{CoreCapability, ContactsCapability},
+		MethodCalls: [][]interface{}{
+			{
+				"ContactCard/set",
+				map[string]interface{}{
+					"accountId": session.AccountID,
+					"destroy":   []string{id},
+				},
+				"deleteContact",
+			},
+		},
+	}
+
+	resp, err := c.MakeRequest(request)
+	if err != nil {
+		return err
+	}
+
+	var result struct {
+		NotDestroyed map[string]struct {
+			Type        string `json:"type"`
+			Description string `json:"description"`
+		} `json:"notDestroyed"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[0][1], &result); err != nil {
+		return err
+	}
+
+	if e, ok := result.NotDestroyed[id]; ok {
+		return fmt.Errorf("failed to delete contact: %s", e.Description)
+	}
+
+	return nil
+}
+
+// parseContactsFromResponse extracts contacts from a JMAP response.
+func (c *Client) parseContactsFromResponse(resp *Response, index int) ([]ContactCard, error) {
+	if len(resp.MethodResponses) <= index {
+		return nil, fmt.Errorf("invalid response: missing method response at index %d", index)
+	}
+
+	var result struct {
+		List     []ContactCard `json:"list"`
+		NotFound []string      `json:"notFound"`
+	}
+
+	if err := json.Unmarshal(resp.MethodResponses[index][1], &result); err != nil {
+		return nil, fmt.Errorf("failed to parse contacts: %w", err)
+	}
+
+	return result.List, nil
+}


### PR DESCRIPTION
## Summary

- Add `fm contacts list` - list contacts with name and email
- Add `fm contacts show <id>` - show full contact details
- Add `fm contacts search <query>` - search contacts
- Add `fm contacts create --name "Name" [--email] [--phone] [--org]` - create contact
- Add `fm contacts delete <id>` - delete with confirmation

## JMAP

Uses JSContact (RFC 9553) ContactCard type via `urn:ietf:params:jmap:contacts` capability.

## Usage

    fm contacts list
    fm contacts search "John"
    fm contacts show C123
    fm contacts create --name "John Doe" --email john@example.com
    fm contacts delete C123