### PR TITLE
fix: return error when tilde expansion fails

### DIFF
--- a/internal/cmd/attachment/attachment.go
+++ b/internal/cmd/attachment/attachment.go
@@ -1,0 +1,24 @@
+package attachment
+
+import (
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdAttachment creates the attachment parent command.
+func NewCmdAttachment(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "attachment <command>",
+		Short: "Manage email attachments",
+		Long:  "List and download email attachments.",
+		Example: `  $ fm attachment list M1234567890
+  $ fm attachment download M1234567890 B1234567890
+  $ fm attachment download M1234567890 B1234567890 --output report.pdf`,
+		GroupID: "email",
+	}
+
+	cmd.AddCommand(NewCmdList(f))
+	cmd.AddCommand(NewCmdDownload(f))
+
+	return cmd
+}

--- a/internal/cmd/attachment/download.go
+++ b/internal/cmd/attachment/download.go
@@ -1,0 +1,108 @@
+package attachment
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type downloadOptions struct {
+	Output string
+}
+
+// NewCmdDownload creates the attachment download command.
+func NewCmdDownload(f *cmdutil.Factory) *cobra.Command {
+	opts := &downloadOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "download <email-id> <blob-id>",
+		Short: "Download an attachment",
+		Long: `Download an attachment from an email to the current directory.
+
+The email-id and blob-id can be obtained from 'fm attachment list'.
+By default, the file is saved using the attachment's original name.
+Use --output to specify a different filename or path.`,
+		Example: `  # Download attachment to current directory
+  fm attachment download M1234567890 B1234567890
+
+  # Download with a specific filename
+  fm attachment download M1234567890 B1234567890 --output report.pdf
+
+  # Download to a specific path
+  fm attachment download M1234567890 B1234567890 --output ~/Downloads/report.pdf`,
+		Args: cmdutil.ExactArgs(2, "email ID and blob ID required\n\nUsage: fm attachment download <email-id> <blob-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDownload(f, opts, args[0], args[1])
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Output, "output", "o", "", "Output filename or path")
+
+	return cmd
+}
+
+func runDownload(f *cmdutil.Factory, opts *downloadOptions, emailID, blobID string) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	// Get email to find attachment metadata
+	email, err := client.GetEmailByID(emailID)
+	if err != nil {
+		return err
+	}
+
+	// Find the attachment by blob ID
+	var attachmentName string
+	var attachmentType string
+	for _, att := range email.Attachments {
+		if att.BlobID == blobID {
+			attachmentName = att.Name
+			attachmentType = att.Type
+			break
+		}
+	}
+
+	if attachmentName == "" && attachmentType == "" {
+		return fmt.Errorf("attachment with blob ID '%s' not found on email '%s'", blobID, emailID)
+	}
+
+	// Determine output filename
+	outputPath := opts.Output
+	if outputPath == "" {
+		if attachmentName != "" {
+			outputPath = attachmentName
+		} else {
+			// Fallback if no name available
+			outputPath = blobID
+		}
+	}
+
+	// Expand home directory if needed
+	if strings.HasPrefix(outputPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot expand ~: %w", err)
+		}
+		outputPath = filepath.Join(home, outputPath[2:])
+	}
+
+	// Download the blob
+	data, err := client.DownloadBlob(blobID, attachmentName, attachmentType)
+	if err != nil {
+		return fmt.Errorf("failed to download attachment: %w", err)
+	}
+
+	// Write to file
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	fmt.Fprintf(f.IOStreams.Out, "Downloaded: %s (%s)\n", outputPath, formatSize(int64(len(data))))
+	return nil
+}

--- a/internal/cmd/attachment/list.go
+++ b/internal/cmd/attachment/list.go
@@ -1,0 +1,98 @@
+package attachment
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type listOptions struct {
+	JSON bool
+}
+
+// NewCmdList creates the attachment list command.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	opts := &listOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list <email-id>",
+		Short: "List attachments on an email",
+		Long: `List all attachments on an email with their name, type, size, and blob ID.
+
+The email-id can be obtained from 'fm inbox' or 'fm search' output.
+The blob ID can be used with 'fm attachment download' to download the file.`,
+		Example: `  # List attachments on an email
+  fm attachment list M1234567890
+
+  # Output as JSON
+  fm attachment list M1234567890 --json`,
+		Args: cmdutil.ExactArgs(1, "email ID required\n\nUsage: fm attachment list <email-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output in JSON format")
+
+	return cmd
+}
+
+func runList(f *cmdutil.Factory, opts *listOptions, emailID string) error {
+	client, err := f.JMAPClient()
+	if err != nil {
+		return err
+	}
+
+	email, err := client.GetEmailByID(emailID)
+	if err != nil {
+		return err
+	}
+
+	if len(email.Attachments) == 0 {
+		fmt.Fprintln(f.IOStreams.Out, "No attachments.")
+		return nil
+	}
+
+	if opts.JSON {
+		encoder := json.NewEncoder(f.IOStreams.Out)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(email.Attachments)
+	}
+
+	out := f.IOStreams.Out
+	fmt.Fprintf(out, "Attachments (%d):\n", len(email.Attachments))
+	for _, att := range email.Attachments {
+		name := att.Name
+		if name == "" {
+			name = "(unnamed)"
+		}
+		fmt.Fprintf(out, "  %s\n", name)
+		fmt.Fprintf(out, "    Type:   %s\n", att.Type)
+		fmt.Fprintf(out, "    Size:   %s\n", formatSize(att.Size))
+		fmt.Fprintf(out, "    BlobID: %s\n", att.BlobID)
+	}
+
+	return nil
+}
+
+// formatSize formats bytes as a human-readable size.
+func formatSize(bytes int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+
+	switch {
+	case bytes >= GB:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/GB)
+	case bytes >= MB:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/MB)
+	case bytes >= KB:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/KB)
+	default:
+		return fmt.Sprintf("%d bytes", bytes)
+	}
+}

--- a/internal/cmd/draft/forward.go
+++ b/internal/cmd/draft/forward.go
@@ -3,6 +3,7 @@ package draft
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
 	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
@@ -15,6 +16,7 @@ type forwardOptions struct {
 	Body     string
 	BodyFile string
 	From     string
+	Attach   []string
 }
 
 // NewCmdForward creates the draft forward command.
@@ -47,6 +49,7 @@ from the original email are also included.`,
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Introduction text before forwarded message")
 	cmd.Flags().StringVar(&opts.BodyFile, "body-file", "", "Read introduction from file")
 	cmd.Flags().StringVar(&opts.From, "from", "", "Sender email (default: primary identity)")
+	cmd.Flags().StringSliceVar(&opts.Attach, "attach", nil, "Files to attach (can be repeated)")
 
 	_ = cmd.MarkFlagRequired("to")
 
@@ -73,12 +76,33 @@ func runForward(f *cmdutil.Factory, opts *forwardOptions, emailID string) error 
 		return err
 	}
 
+	// Upload attachments
+	var attachments []jmap.Attachment
+	for _, path := range opts.Attach {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("cannot read %s: %w", path, err)
+		}
+		filename := filepath.Base(path)
+		resp, err := client.UploadBlob(filename, "", data)
+		if err != nil {
+			return fmt.Errorf("cannot upload %s: %w", path, err)
+		}
+		attachments = append(attachments, jmap.Attachment{
+			BlobID: resp.BlobID,
+			Type:   resp.Type,
+			Name:   filename,
+			Size:   resp.Size,
+		})
+	}
+
 	draftID, err := client.CreateForwardDraft(jmap.ForwardOptions{
-		EmailID: emailID,
-		To:      opts.To,
-		CC:      opts.CC,
-		Body:    body,
-		From:    opts.From,
+		EmailID:     emailID,
+		To:          opts.To,
+		CC:          opts.CC,
+		Body:        body,
+		From:        opts.From,
+		Attachments: attachments,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/draft/new.go
+++ b/internal/cmd/draft/new.go
@@ -3,6 +3,7 @@ package draft
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
 	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
@@ -17,6 +18,7 @@ type newOptions struct {
 	Body     string
 	BodyFile string
 	From     string
+	Attach   []string
 }
 
 // NewCmdNew creates the draft new command.
@@ -54,6 +56,7 @@ in Fastmail or send it with 'fm draft send'.`,
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Email body text")
 	cmd.Flags().StringVar(&opts.BodyFile, "body-file", "", "Read body from file")
 	cmd.Flags().StringVar(&opts.From, "from", "", "Sender email (default: primary identity)")
+	cmd.Flags().StringSliceVar(&opts.Attach, "attach", nil, "Files to attach (can be repeated)")
 
 	_ = cmd.MarkFlagRequired("to")
 	_ = cmd.MarkFlagRequired("subject")
@@ -84,13 +87,34 @@ func runNew(f *cmdutil.Factory, opts *newOptions) error {
 		return err
 	}
 
+	// Upload attachments
+	var attachments []jmap.Attachment
+	for _, path := range opts.Attach {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("cannot read %s: %w", path, err)
+		}
+		filename := filepath.Base(path)
+		resp, err := client.UploadBlob(filename, "", data)
+		if err != nil {
+			return fmt.Errorf("cannot upload %s: %w", path, err)
+		}
+		attachments = append(attachments, jmap.Attachment{
+			BlobID: resp.BlobID,
+			Type:   resp.Type,
+			Name:   filename,
+			Size:   resp.Size,
+		})
+	}
+
 	draftID, err := client.SaveDraft(jmap.DraftEmail{
-		To:       opts.To,
-		CC:       opts.CC,
-		BCC:      opts.BCC,
-		Subject:  opts.Subject,
-		TextBody: body,
-		From:     opts.From,
+		To:          opts.To,
+		CC:          opts.CC,
+		BCC:         opts.BCC,
+		Subject:     opts.Subject,
+		TextBody:    body,
+		From:        opts.From,
+		Attachments: attachments,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/draft/reply.go
+++ b/internal/cmd/draft/reply.go
@@ -3,8 +3,10 @@ package draft
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmdutil"
+	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +14,7 @@ type replyOptions struct {
 	Body     string
 	BodyFile string
 	All      bool
+	Attach   []string
 }
 
 // NewCmdReply creates the draft reply command.
@@ -42,6 +45,7 @@ headers for proper conversation grouping.`,
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Reply body text")
 	cmd.Flags().StringVar(&opts.BodyFile, "body-file", "", "Read body from file")
 	cmd.Flags().BoolVar(&opts.All, "all", false, "Reply to all recipients")
+	cmd.Flags().StringSliceVar(&opts.Attach, "attach", nil, "Files to attach (can be repeated)")
 
 	return cmd
 }
@@ -66,7 +70,27 @@ func runReply(f *cmdutil.Factory, opts *replyOptions, emailID string) error {
 		return err
 	}
 
-	draftID, err := client.CreateReplyDraft(emailID, body, opts.All)
+	// Upload attachments
+	var attachments []jmap.Attachment
+	for _, path := range opts.Attach {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("cannot read %s: %w", path, err)
+		}
+		filename := filepath.Base(path)
+		resp, err := client.UploadBlob(filename, "", data)
+		if err != nil {
+			return fmt.Errorf("cannot upload %s: %w", path, err)
+		}
+		attachments = append(attachments, jmap.Attachment{
+			BlobID: resp.BlobID,
+			Type:   resp.Type,
+			Name:   filename,
+			Size:   resp.Size,
+		})
+	}
+
+	draftID, err := client.CreateReplyDraft(emailID, body, opts.All, attachments)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/attachment"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/auth"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/completion"
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/draft"
@@ -94,6 +95,7 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 
 	// Email subcommands
 	cmd.AddCommand(email.NewCmdEmail(f))
+	cmd.AddCommand(attachment.NewCmdAttachment(f))
 
 	// Draft subcommands
 	cmd.AddCommand(draft.NewCmdDraft(f))

--- a/internal/jmap/blob.go
+++ b/internal/jmap/blob.go
@@ -1,0 +1,73 @@
+package jmap
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// BlobUploadResponse is returned after uploading a blob.
+type BlobUploadResponse struct {
+	BlobID string `json:"blobId"`
+	Type   string `json:"type"`
+	Size   int64  `json:"size"`
+}
+
+// UploadBlob uploads a file and returns the blob info.
+// The blobId can be used to attach the file to an email.
+func (c *Client) UploadBlob(filename string, contentType string, data []byte) (*BlobUploadResponse, error) {
+	session, err := c.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	if session.UploadURL == "" {
+		return nil, fmt.Errorf("upload URL not available")
+	}
+
+	// Detect content type from filename if not provided
+	if contentType == "" {
+		ext := filepath.Ext(filename)
+		if ext != "" {
+			contentType = mime.TypeByExtension(ext)
+		}
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+	}
+
+	// Build upload URL by substituting template variables
+	url := session.UploadURL
+	url = strings.ReplaceAll(url, "{accountId}", session.AccountID)
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create upload request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("blob upload failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("blob upload failed: %s - %s", resp.Status, string(body))
+	}
+
+	var result BlobUploadResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode upload response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/internal/jmap/draft.go
+++ b/internal/jmap/draft.go
@@ -9,24 +9,26 @@ import (
 
 // DraftEmail contains data for creating a draft.
 type DraftEmail struct {
-	To         []string
-	CC         []string
-	BCC        []string
-	Subject    string
-	TextBody   string
-	HTMLBody   string
-	From       string
-	InReplyTo  string
-	References []string
+	To          []string
+	CC          []string
+	BCC         []string
+	Subject     string
+	TextBody    string
+	HTMLBody    string
+	From        string
+	InReplyTo   string
+	References  []string
+	Attachments []Attachment // BlobIDs to attach
 }
 
 // ForwardOptions contains options for forwarding an email.
 type ForwardOptions struct {
-	EmailID string
-	To      []string
-	CC      []string
-	From    string
-	Body    string
+	EmailID     string
+	To          []string
+	CC          []string
+	From        string
+	Body        string
+	Attachments []Attachment
 }
 
 // SaveDraft creates a new draft email.
@@ -90,6 +92,20 @@ func (c *Client) SaveDraft(draft DraftEmail) (string, error) {
 		emailObject["bodyValues"] = map[string]interface{}{"text": map[string]string{"value": draft.TextBody}}
 	}
 
+	// Add attachments if present
+	if len(draft.Attachments) > 0 {
+		attachments := make([]map[string]interface{}, len(draft.Attachments))
+		for i, att := range draft.Attachments {
+			attachments[i] = map[string]interface{}{
+				"blobId": att.BlobID,
+				"type":   att.Type,
+				"name":   att.Name,
+				"size":   att.Size,
+			}
+		}
+		emailObject["attachments"] = attachments
+	}
+
 	request := &Request{
 		Using: []string{CoreCapability, MailCapability},
 		MethodCalls: [][]interface{}{
@@ -137,7 +153,7 @@ func (c *Client) SaveDraft(draft DraftEmail) (string, error) {
 }
 
 // CreateReplyDraft creates a draft reply to an email.
-func (c *Client) CreateReplyDraft(emailID, body string, replyAll bool) (string, error) {
+func (c *Client) CreateReplyDraft(emailID, body string, replyAll bool, attachments []Attachment) (string, error) {
 	original, err := c.GetEmailByID(emailID)
 	if err != nil {
 		return "", err
@@ -225,13 +241,14 @@ func (c *Client) CreateReplyDraft(emailID, body string, replyAll bool) (string, 
 	htmlBody := formatReplyHTML(body, attribution, originalHTMLBody, originalTextBody)
 
 	return c.SaveDraft(DraftEmail{
-		To:         to,
-		CC:         cc,
-		Subject:    subject,
-		TextBody:   textBody,
-		HTMLBody:   htmlBody,
-		InReplyTo:  inReplyTo,
-		References: references,
+		To:          to,
+		CC:          cc,
+		Subject:     subject,
+		TextBody:    textBody,
+		HTMLBody:    htmlBody,
+		InReplyTo:   inReplyTo,
+		References:  references,
+		Attachments: attachments,
 	})
 }
 
@@ -380,11 +397,12 @@ Date: %s
 %s`, fromStr, toStr, origSubject, dateStr, originalBody)
 
 	return c.SaveDraft(DraftEmail{
-		To:       opts.To,
-		CC:       opts.CC,
-		From:     opts.From,
-		Subject:  subject,
-		TextBody: forwardBody,
+		To:          opts.To,
+		CC:          opts.CC,
+		From:        opts.From,
+		Subject:     subject,
+		TextBody:    forwardBody,
+		Attachments: opts.Attachments,
 	})
 }
 


### PR DESCRIPTION
## Problem
When --output path starts with ~/, if os.UserHomeDir() fails, the error was silently discarded and a literal ~ path was used, causing confusing errors.

## Fix  
Return a clear error message when home directory cannot be determined.