### PR TITLE
feat: add User-Agent header to JMAP requests

### DIFF
--- a/cmd/fm/main.go
+++ b/cmd/fm/main.go
@@ -4,8 +4,10 @@ import (
 	"os"
 
 	"github.com/marckohlbrugge/fastmail-cli/internal/cmd/root"
+	"github.com/marckohlbrugge/fastmail-cli/internal/jmap"
 )
 
 func main() {
+	jmap.Version = root.Version
 	os.Exit(root.Execute())
 }

--- a/internal/jmap/client.go
+++ b/internal/jmap/client.go
@@ -14,6 +14,9 @@ const (
 	SessionPath    = "/jmap/session"
 )
 
+// Version is set at build time or by main.
+var Version = "dev"
+
 // Client is a JMAP client for Fastmail.
 type Client struct {
 	token      string
@@ -150,6 +153,7 @@ func (c *Client) MakeRequest(request *Request) (*Response, error) {
 func (c *Client) setAuthHeaders(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "fm/"+Version)
 }
 
 // AccountID returns the current account ID.


### PR DESCRIPTION
## Summary
- Adds User-Agent header to all JMAP requests: `fm/{version}`
- Version synced from root.Version (set via ldflags at build time)

## Changes
- `internal/jmap/client.go`: Add `Version` var, set User-Agent in `setAuthHeaders()`
- `cmd/fm/main.go`: Sync `jmap.Version = root.Version` before Execute()